### PR TITLE
Reflect Agent Implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine:3.16
+
+WORKDIR /opt/reflect-agent
+
+# System dependencies
+RUN apk --no-cache add \
+  bind-tools \
+  wireguard-tools \
+  iptables \
+  ip6tables \
+  inotify-tools \
+  jq \
+  curl
+
+# Install 3proxy from source
+ENV THREEPROXY_VERSION=0.9.4
+
+RUN apk add alpine-sdk && \
+  export DIR=$(mktemp -d) && \
+  cd $DIR && \
+  wget https://github.com/3proxy/3proxy/archive/refs/tags/${THREEPROXY_VERSION}.tar.gz && \
+  tar -xf ${THREEPROXY_VERSION}.tar.gz && \
+  rm ${THREEPROXY_VERSION}.tar.gz && \
+  mv 3proxy* 3proxy && \
+  cd 3proxy && \
+  make -f Makefile.Linux || true && \
+  mv bin/3proxy /opt/reflect-agent/3proxy && \
+  cd && \
+  rm -rf $DIR && \
+  apk del alpine-sdk
+
+COPY src/ src/
+RUN chmod +x src/*.sh
+
+WORKDIR /opt/reflect-agent/src
+
+# Entry point.
+CMD ["sh", "./entrypoint.sh"]
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,82 @@
 # Reflect Agent
 
+[Reflect](https://reflect.run) is a regression testing platform for web applications,
+which replaces manual and code-based testing with automated test runs and failure notifications.
+
+The Reflect Agent is a networked deamon that establishes a secure tunnel
+from an internal local area network back to Reflect.
+This allows customers to use Reflect's cloud-based platform
+to create and run tests against private, non-publicly-accessible applications.
+
+The Reflect Agent runs as a docker container on a host within the private network.
+It establishes a [Wireguard](https://www.wireguard.com/) tunnel to Reflect's API
+through which the Reflect browsers can reach applications in the private network.
+
 ## Background
 
+Reflect is a cloud-based platform where users can instantiate browser instances and
+interact with their own web applications through those cloud browsers.
+From these interactions, Reflect automatically generates repeatable test cases.
+Then, users can run those test cases against their applications without manual intervention.
+Reflect notifies users if the test cases were succesfully performed or not.
+
+Since Reflect's browsers run on the public Internet, the web application under test must be publicly accessible.
+However, some web applications are not publicly-accessible on the Internet.
+In these cases, users run the Reflect Agent to establish a secure network connection
+between their environment and the Reflect platform.
+This allows private web applications to be accessible, but only to Reflect's cloud browsers.
+
 ## Installation
+
+The simplest installation is to run the agent on a host
+that has both a public and private IP address,
+where the private IP address is on the same network subnet as the private web applications to be tested.
+The agent will bind to a UDP port on the public IP address and listen for incoming Reflect browser sessions.
+Typically, the host will have a restricted network ACL limited to allowing traffic only from Reflect.
+
+NOTE: installing the agent behind a NAT requires establishing a port-forwarding rule
+on the NAT for the UDP port that the agent binds to.
+
+To install the agent, you'll need `docker` installed, and then run:
+
+```
+$ ./build-agent.sh
+```
+
+(In the future, Reflect may release an official container image publicly.)
+
+## Running the Agent
+
+To run the agent, you'll need your Reflect account API key,
+which can be found on the __Settings__ page in the Reflect web UI.
+
+Additionally, you can optionally specify the public UDP port that the agent
+will bind to in order to listen for connections from Reflect cloud browsers.
+
+Then, run:
+
+```
+$ ./run-agent.sh <reflect-api-key> [UDP port]
+```
+
+The agent will generate a new keypair when it launches and
+register with Reflect using your account API key.
+Then, it will listen for connections from Reflect browser sessions indefinitely.
+
+NOTE: Reflect only supports a single agent per account.
+As a result, you should not run multiple agents at once.
+In all cases, the last agent to register is the only agent that Reflect recognizes.
+
+## Stopping the Agent
+
+To stop the agent, run:
+
+```
+$ ./stop-agent.sh
+```
+
+## Support
+
+For questions about using the Reflect Agent with your Reflect account,
+please email us at support@reflect.run and we'll be glad to assist.
 

--- a/build-agent.sh
+++ b/build-agent.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t agent .

--- a/run-agent.sh
+++ b/run-agent.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <reflect-api-key> [public-port]"
+  exit 1
+fi
+
+ReflectApiKey=$1
+PublicPort="${2:-10009}"
+
+echo "=== Running Reflect Agent ==="
+echo "PublicPort=$PublicPort"
+
+docker run --rm --cap-add net_admin -d \
+  --name agent \
+  -e ReflectApiKey=$ReflectApiKey \
+  -e PublicPort=$PublicPort \
+  -p $PublicPort:$PublicPort/udp \
+  agent
+

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$ReflectApiKey" ]; then
+  echo "Missing environment variable 'ReflectApiKey'"
+  exit 1
+fi
+
+if [ -z "$PublicPort" ]; then
+  echo "Missing environment variable 'PublicPort'"
+  exit 1
+fi
+
+echo "=== Reflect Agent ==="
+
+PrivateKeyFile="private.key"
+PublicKeyFile="public.key"
+RegistrationResponseFile="response.json"
+
+./keypair.sh $PrivateKeyFile $PublicKeyFile
+
+PublicKey=$(cat $PublicKeyFile)
+./register.sh $ReflectApiKey $PublicKey $PublicPort $RegistrationResponseFile
+
+ProxyIp=$(jq -r '.proxyIp' $RegistrationResponseFile)
+ProxyPort=$(jq -r '.proxyPort' $RegistrationResponseFile)
+./proxy.sh $ProxyIp $ProxyPort
+
+WireguardIp=$(jq -r '.privateIp' $RegistrationResponseFile)
+PrivateKey=$(cat $PrivateKeyFile)
+PeerPublicKey=$(jq -r '.sessionsPublicKey' $RegistrationResponseFile)
+PeerIps=$(jq -r '.sessionsIpsNetmask | join(", ")' $RegistrationResponseFile)
+./wireguard.sh $WireguardIp $PublicPort $PrivateKey $PeerPublicKey $PeerIps
+
+HeartbeatIntervalSecs=600
+./heartbeat.sh $ReflectApiKey $PublicKey $HeartbeatIntervalSecs
+
+sleep infinity &
+wait $!
+
+echo "done"

--- a/src/heartbeat.sh
+++ b/src/heartbeat.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 3 ]; then
+  echo "usage: $0 <reflect-api-key> <public-key> <interval-seconds>"
+  exit 1
+fi
+
+ReflectApiKey=$1
+PublicKey=$2
+Seconds=$3
+
+echo "=== Establishing heartbeat check-in"
+
+while true; do
+
+  curl -s -X PUT \
+    -o /dev/null \
+    -H "X-API-KEY: $ReflectApiKey" \
+    https://api.reflect.run/v1/agents/$PublicKey/heartbeat
+
+  sleep $Seconds
+
+done
+

--- a/src/keypair.sh
+++ b/src/keypair.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <private-key-outfile> <public-key-outfile>"
+  exit 1
+fi
+
+PrivateKeyOutfile=$1
+PublicKeyOutfile=$2
+
+echo "=== Generating keypair ==="
+
+PrivateKey=$(wg genkey)
+PublicKey=$(echo $PrivateKey | wg pubkey)
+
+echo $PrivateKey > $PrivateKeyOutfile
+echo $PublicKey > $PublicKeyOutfile
+
+echo "Wrote keys: priv=$PrivateKeyOutfile, pub=$PublicKeyOutfile"
+

--- a/src/proxy.sh
+++ b/src/proxy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <proxy-ip> <proxy-port>"
+  exit 1
+fi
+
+ProxyIp=$1
+ProxyPort=$2
+
+ProxyCIDR="${ProxyIp}/24"
+ProxyDevice="proxy0"
+ProxyBinary="/opt/reflect-agent/3proxy"
+
+echo "=== Creating proxy interface ($ProxyDevice)"
+
+ip link add dev $ProxyDevice type dummy
+ip address add dev $ProxyDevice $ProxyCIDR
+ip link set up dev $ProxyDevice
+
+echo "=== Running proxy at ${ProxyIp}:${ProxyPort}"
+
+ProxyConfig="socks -p${ProxyPort} -i${ProxyIp}"
+echo $ProxyConfig | $ProxyBinary &
+

--- a/src/register.sh
+++ b/src/register.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 4 ]; then
+  echo "usage: $0 <reflect-api-key> <public-key> <public-port> <response-outfile>"
+  exit 1
+fi
+
+ReflectApiKey=$1
+PublicKey=$2
+PublicPort=$3
+ResponseFile=$4
+
+RequestFile=request.json
+
+echo "=== Registering agent ==="
+
+cat << EOF > $RequestFile
+{
+  "publicKey": "${PublicKey}",
+  "port": $PublicPort
+}
+EOF
+
+RequestString=$(jq -c '.' $RequestFile)
+
+curl -s -X POST \
+  --data-raw "$RequestString" \
+  -o $ResponseFile \
+  -H "X-API-KEY: $ReflectApiKey" \
+  https://api.reflect.run/v1/agents
+
+echo "=== Registration response in '$ResponseFile'"
+

--- a/src/wireguard.sh
+++ b/src/wireguard.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 5 ]; then
+  echo "usage: $0 <wireguard-ip> <wireguard-port> <private-key> <peer-public-key> <peer-ips>"
+  exit 1
+fi
+
+WireguardIp=$1
+WireguardPort=$2
+PrivateKey=$3
+PeerPublicKey=$4
+PeerIps=$5
+
+WireguardConfigFile="/etc/wireguard/wg0.conf"
+
+echo "=== Installing Wireguard ($WireguardConfigFile) for $WireguardIp:$WireguardPort"
+
+cat << EOF > $WireguardConfigFile
+[Interface]
+Address = $WireguardIp
+PrivateKey = $PrivateKey
+ListenPort = $WireguardPort
+
+[Peer]
+PublicKey = $PeerPublicKey
+AllowedIPs = $PeerIps
+EOF
+
+echo "=== Bringing up Wireguard interface"
+
+wg-quick up $WireguardConfigFile
+

--- a/stop-agent.sh
+++ b/stop-agent.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker kill agent
+


### PR DESCRIPTION
Fixes #1 

This adds an initial implementation for the various components:
- Building the agent locally,
- Scripts for the agent to:
  - generate a keypair
  - register with the Reflect API
  - start the proxy server
  - install wireguard
  - send a heartbeat

More information is available in the README.

**Tested**
- Built and ran the agent, and
verified it registers and checks in with the Reflect API