### PR TITLE
URI encode the public key in heartbeats

### DIFF
--- a/src/heartbeat.sh
+++ b/src/heartbeat.sh
@@ -13,12 +13,14 @@ Seconds=$3
 
 echo "=== Establishing heartbeat check-in"
 
+EncodedPublicKey=$(echo $PublicKey | jq -R -r @uri)
+
 while true; do
 
   curl -s -X PUT \
     -o /dev/null \
     -H "X-API-KEY: $ReflectApiKey" \
-    https://api.reflect.run/v1/agents/$PublicKey/heartbeat
+    https://api.reflect.run/v1/agents/$EncodedPublicKey/heartbeat
 
   sleep $Seconds
 


### PR DESCRIPTION
This commit updates the bytes that we send to the Reflect API heartbeat endpoint. Since the wireguard public key can contain URI-reserved characters, we need to percent-encode it to replace those reserved characters. This commit adds the encoding to the public key before using it in the HTTP request. The Reflect API server will expect the public key to use this percent-encoding.

**Tested**
- Ran the agent locally and verified that it checks-in successfully with the Reflet API