### PR TITLE
Add support for NAT traversal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,9 @@ RUN chmod +x src/*.sh
 
 WORKDIR /opt/reflect-agent/src
 
+RUN apk add alpine-sdk && \
+  gcc -o udp-punch udp-punch.c && \
+  apk del alpine-sdk
+
 # Entry point.
 CMD ["sh", "./entrypoint.sh"]

--- a/run-agent.sh
+++ b/run-agent.sh
@@ -1,19 +1,52 @@
 #!/bin/bash
 
-if [ $# -lt 1 ]; then
-  echo "usage: $0 <reflect-api-key> [public-port]"
+PublicPort=10009
+WithNat="false"
+
+function usage {
+  echo "usage: $0 -k <reflect_api_key> [-p <public_port] [-n]"
+  echo -e "\tRuns the Reflect Agent and connects to the specified Reflect account"
+  echo
+  echo -e "\t-k reflect_api_key"
+  echo -e "\t\tThe API key for the Reflect account"
+  echo
+  echo -e "\t-p public_port"
+  echo -e "\t\tThe public port on the host machine, default $PublicPort"
+  echo
+  echo -e "\t-n"
+  echo -e "\t\tUse a persistent connection to Reflect when behind a NAT, default $WithNat"
+  echo
   exit 1
+}
+
+while getopts ":k:p:n" option; do
+    case "${option}" in
+        k)
+            ReflectApiKey=${OPTARG}
+            ;;
+        p)
+            PublicPort=${OPTARG}
+            ;;
+        n)
+            WithNat="true"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${ReflectApiKey}" ]; then
+    usage
 fi
 
-ReflectApiKey=$1
-PublicPort="${2:-10009}"
-
-echo "=== Running Reflect Agent ==="
-echo "PublicPort=$PublicPort"
+echo "Reflect Agent running on port $PublicPort"
 
 docker run --rm --cap-add net_admin -d \
   --name agent \
   -e ReflectApiKey=$ReflectApiKey \
   -e PublicPort=$PublicPort \
+  -e WithNat=$WithNat \
   -p $PublicPort:$PublicPort/udp \
   agent

--- a/src/heartbeat.sh
+++ b/src/heartbeat.sh
@@ -2,25 +2,45 @@
 
 set -e
 
-if [ $# -lt 3 ]; then
-  echo "usage: $0 <reflect-api-key> <public-key> <interval-seconds>"
+if [ $# -lt 5 ]; then
+  echo "usage: $0 <reflect-api-key> <private-key> <public-key> <public-port> <interval-seconds>"
   exit 1
 fi
 
 ReflectApiKey=$1
-PublicKey=$2
-Seconds=$3
+PrivateKey=$2
+PublicKey=$3
+PublicPort=$4
+Seconds=$5
 
-echo "=== Establishing heartbeat check-in"
+ResponseFile="heartbeat-response.json"
+SessionsFile="sessions.json"
+LastSHA=""
+
+echo "agent: initiating heartbeat"
 
 EncodedPublicKey=$(echo $PublicKey | jq -R -r @uri)
 
 while true; do
 
   curl -s -X PUT \
-    -o /dev/null \
+    -o $ResponseFile \
     -H "X-API-KEY: $ReflectApiKey" \
     https://api.reflect.run/v1/agents/$EncodedPublicKey/heartbeat
+
+  CurrentSHA=$(sha256sum $ResponseFile)
+
+  if [ "$CurrentSHA" != "$LastSHA" ]; then
+    # Update the wireguard configuration since the sessions have changed.
+
+    WireguardIp=$(jq -r '.privateIp' $ResponseFile)
+    jq -r '.activeSessions' $ResponseFile > $SessionsFile
+
+    ./wireguard.sh $WireguardIp $PrivateKey $PublicPort $SessionsFile
+
+  fi
+
+  LastSHA=$CurrentSHA
 
   sleep $Seconds
 

--- a/src/keypair.sh
+++ b/src/keypair.sh
@@ -10,7 +10,7 @@ fi
 PrivateKeyOutfile=$1
 PublicKeyOutfile=$2
 
-echo "=== Generating keypair ==="
+echo "agent: generating keypair"
 
 PrivateKey=$(wg genkey)
 PublicKey=$(echo $PrivateKey | wg pubkey)
@@ -18,4 +18,4 @@ PublicKey=$(echo $PrivateKey | wg pubkey)
 echo $PrivateKey > $PrivateKeyOutfile
 echo $PublicKey > $PublicKeyOutfile
 
-echo "Wrote keys: priv=$PrivateKeyOutfile, pub=$PublicKeyOutfile"
+echo "agent: wrote keys (priv=$PrivateKeyOutfile, pub=$PublicKeyOutfile)"

--- a/src/proxy.sh
+++ b/src/proxy.sh
@@ -14,13 +14,13 @@ ProxyCIDR="${ProxyIp}/24"
 ProxyDevice="proxy0"
 ProxyBinary="/opt/reflect-agent/3proxy"
 
-echo "=== Creating proxy interface ($ProxyDevice)"
+echo "agent: creating proxy interface ($ProxyDevice)"
 
 ip link add dev $ProxyDevice type dummy
 ip address add dev $ProxyDevice $ProxyCIDR
 ip link set up dev $ProxyDevice
 
-echo "=== Running proxy at ${ProxyIp}:${ProxyPort}"
+echo "agent: running proxy at ${ProxyIp}:${ProxyPort}"
 
 ProxyConfig="socks -p${ProxyPort} -i${ProxyIp}"
 echo $ProxyConfig | $ProxyBinary &

--- a/src/register.sh
+++ b/src/register.sh
@@ -14,7 +14,7 @@ ResponseFile=$4
 
 RequestFile=request.json
 
-echo "=== Registering agent ==="
+echo "agent: registering"
 
 cat << EOF > $RequestFile
 {
@@ -31,4 +31,3 @@ curl -s -X POST \
   -H "X-API-KEY: $ReflectApiKey" \
   https://api.reflect.run/v1/agents
 
-echo "=== Registration response in '$ResponseFile'"

--- a/src/udp-punch.c
+++ b/src/udp-punch.c
@@ -1,0 +1,90 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/udp.h>
+
+unsigned short checksum(unsigned short *buf, int len) {
+  unsigned long sum;
+
+  for(sum = 0; len > 0; len--) {
+    sum += *buf++;
+  }
+
+  sum = (sum >> 16) + (sum & 0xffff);
+  sum += (sum >> 16);
+  return (unsigned short)(~sum);
+}
+
+int main(int argc, char const *argv[]) {
+  int enabled = 1;
+  char buffer[1024];
+  memset(buffer, 0, 1024);
+
+  struct iphdr *ip = (struct iphdr *) buffer;
+  struct udphdr *udp = (struct udphdr *) (buffer + sizeof(struct iphdr));
+
+  // Validate arguments.
+  if (argc < 5) {
+    printf("Usage: %s <source IP> <source port> <destination IP> <target port>\n", argv[0]);
+    return EXIT_FAILURE;
+  }
+
+  uint32_t src_addr = inet_addr(argv[1]);
+  uint16_t src_port = atoi(argv[2]);
+  uint32_t dst_addr = inet_addr(argv[3]);
+  uint16_t dst_port = atoi(argv[4]);
+
+  // Create and configure the socket.
+  int socket_fd;
+  if ((socket_fd = socket(PF_INET, SOCK_RAW, IPPROTO_UDP)) < 0) {
+    perror("Failed to create IP socket");
+    return EXIT_FAILURE;
+  }
+
+  if(setsockopt(socket_fd, IPPROTO_IP, IP_HDRINCL, &enabled, sizeof(enabled)) < 0) {
+    perror("Failed to configure header includes on the socket");
+    return EXIT_FAILURE;
+  }
+
+  // Construct the IP and UDP packet headers.
+  ip->ihl = 5;
+  ip->version = 4;
+  ip->tos = 16; // low delay
+  ip->tot_len = sizeof(struct iphdr) + sizeof(struct udphdr);
+  ip->id = htons(11637);
+  ip->ttl = 64;
+  ip->protocol = 17; // UDP
+  ip->saddr = src_addr;
+  ip->daddr = dst_addr;
+
+  udp->uh_sport = htons(src_port);
+  udp->uh_dport = htons(dst_port);
+  udp->uh_ulen = htons(sizeof(struct udphdr));
+
+  ip->check = checksum((unsigned short *)buffer, ip->tot_len);
+
+  // Send the datagram to the destination.
+  struct sockaddr_in sin;
+  sin.sin_family = AF_INET;
+  sin.sin_port = htons(dst_port);
+  sin.sin_addr.s_addr = dst_addr;
+
+  if (sendto(socket_fd, buffer, ip->tot_len, 0, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
+    perror("Failed to send datagram");
+    return EXIT_FAILURE;
+  }
+
+  printf("Datagram sent\n");
+
+  // Cleanup.
+  close(socket_fd);
+
+  return EXIT_SUCCESS;
+}
+

--- a/src/wireguard.sh
+++ b/src/wireguard.sh
@@ -2,32 +2,61 @@
 
 set -e
 
-if [ $# -lt 5 ]; then
-  echo "usage: $0 <wireguard-ip> <wireguard-port> <private-key> <peer-public-key> <peer-ips>"
+# This inherits the WithNat environment variable from entrypoint.sh.
+
+if [ $# -lt 4 ]; then
+  echo "usage: $0 <wireguard-ip> <private-key> <wireguard-port> <peers-file>"
   exit 1
 fi
 
 WireguardIp=$1
-WireguardPort=$2
-PrivateKey=$3
-PeerPublicKey=$4
-PeerIps=$5
+PrivateKey=$2
+WireguardPort=$3
+PeersFile=$4
 
+UdpPunchIp="0.0.0.0"
 WireguardConfigFile="/etc/wireguard/wg0.conf"
 
-echo "=== Installing Wireguard ($WireguardConfigFile) for $WireguardIp:$WireguardPort"
+echo "agent: installing wireguard ($WireguardConfigFile) for $WireguardIp:$WireguardPort"
 
+# Create the initial configuration.
 cat << EOF > $WireguardConfigFile
 [Interface]
 Address = $WireguardIp
 PrivateKey = $PrivateKey
 ListenPort = $WireguardPort
 
-[Peer]
-PublicKey = $PeerPublicKey
-AllowedIPs = $PeerIps
 EOF
 
-echo "=== Bringing up Wireguard interface"
+# Append each peer to the configuration.
+cat $PeersFile | \
+  jq -r \
+  '.[] | .publicKey + " " + .allowedIp + " " + .endpoint.ip + " " + (.endpoint.port|tostring)' | \
+  while read Key AllowedIp EndpointIp EndpointPort; do
+    Endpoint="${EndpointIp}:${EndpointPort}"
+
+    if [ "${WithNat}" == "true" ]; then
+      echo "agent: sending datagram to $Endpoint"
+      ./udp-punch $UdpPunchIp $WireguardPort $EndpointIp $EndpointPort
+    fi
+
+    echo "[Peer]" >> $WireguardConfigFile
+    echo "PublicKey = $Key" >> $WireguardConfigFile
+    echo "AllowedIPs = $AllowedIp" >> $WireguardConfigFile
+    echo "Endpoint = $Endpoint" >> $WireguardConfigFile
+
+    if [ "${WithNat}" == "true" ]; then
+      echo "PersistentKeepalive = 25" >> $WireguardConfigFile
+    fi
+
+    echo >> $WireguardConfigFile
+  done
+
+echo "agent: toggling wireguard interface"
+
+IsRunning=$(wg | wc -c) # Hack to determine if it's running
+if [ "$IsRunning" != "0" ]; then
+  wg-quick down $WireguardConfigFile
+fi
 
 wg-quick up $WireguardConfigFile


### PR DESCRIPTION
Fixes #6

This commit updates the agent to support a new flag, `-n`, for agents behind NATs.
When set, this flag causes the agent to use wireguard's keepalive heartbeat.
Additionally, this sends a raw UDP datagram to ensure the hole is punched.

In relation to this change, the Reflect API was updated to include information
about active browser sessions, which allows the agent to initiate each connection.
Previously, the agent acted as the server in the wireguard connection.
This commit reverses the connection so that the agent acts as a client,
which connects to each individual session as a distinct peer in the wireguard network.

Finally, it updates the agent to use more formal argument parsing, and
updates all of the log lines to be more consistent and simpler.

**Tested**
- Ran the agent behind a NAT and verified it registers and checks in
- Verified that new recording and test run sessions are identified and
  installed as peers into the wireguard configuration.
- Verified that the sessions in Reflect use the proxy successfully.
- Verified that running the agent without the `-n` flag is successful