### PR TITLE
Always establish connection from agent to sessions

### DIFF
--- a/run-agent.sh
+++ b/run-agent.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 PublicPort=10009
-WithNat="false"
 
 function usage {
   echo "usage: $0 -k <reflect_api_key> [-p <public_port] [-n]"
@@ -13,22 +12,16 @@ function usage {
   echo -e "\t-p public_port"
   echo -e "\t\tThe public port on the host machine, default $PublicPort"
   echo
-  echo -e "\t-n"
-  echo -e "\t\tUse a persistent connection to Reflect when behind a NAT, default $WithNat"
-  echo
   exit 1
 }
 
-while getopts ":k:p:n" option; do
+while getopts ":k:p:" option; do
     case "${option}" in
         k)
             ReflectApiKey=${OPTARG}
             ;;
         p)
             PublicPort=${OPTARG}
-            ;;
-        n)
-            WithNat="true"
             ;;
         *)
             usage
@@ -47,6 +40,5 @@ docker run --rm --cap-add net_admin -d \
   --name agent \
   -e ReflectApiKey=$ReflectApiKey \
   -e PublicPort=$PublicPort \
-  -e WithNat=$WithNat \
   -p $PublicPort:$PublicPort/udp \
   agent

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -12,11 +12,6 @@ if [ -z "$PublicPort" ]; then
   exit 1
 fi
 
-if [ -z "$WithNat" ]; then
-  echo "Missing environment variable 'WithNat'"
-  exit 1
-fi
-
 echo "agent: starting"
 
 PrivateKeyFile="private.key"

--- a/src/wireguard.sh
+++ b/src/wireguard.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-# This inherits the WithNat environment variable from entrypoint.sh.
-
 if [ $# -lt 4 ]; then
   echo "usage: $0 <wireguard-ip> <private-key> <wireguard-port> <peers-file>"
   exit 1
@@ -35,19 +33,14 @@ cat $PeersFile | \
   while read Key AllowedIp EndpointIp EndpointPort; do
     Endpoint="${EndpointIp}:${EndpointPort}"
 
-    if [ "${WithNat}" == "true" ]; then
-      echo "agent: sending datagram to $Endpoint"
-      ./udp-punch $UdpPunchIp $WireguardPort $EndpointIp $EndpointPort
-    fi
+    echo "agent: sending datagram to $Endpoint"
+    ./udp-punch $UdpPunchIp $WireguardPort $EndpointIp $EndpointPort
 
     echo "[Peer]" >> $WireguardConfigFile
     echo "PublicKey = $Key" >> $WireguardConfigFile
     echo "AllowedIPs = $AllowedIp" >> $WireguardConfigFile
     echo "Endpoint = $Endpoint" >> $WireguardConfigFile
-
-    if [ "${WithNat}" == "true" ]; then
-      echo "PersistentKeepalive = 25" >> $WireguardConfigFile
-    fi
+    echo "PersistentKeepalive = 25" >> $WireguardConfigFile
 
     echo >> $WireguardConfigFile
   done


### PR DESCRIPTION
This commit updates the agent to always proactively establish a connection to the active sessions it learns about through the heartbeat. Effectively, this uses the NAT-traversal behavior at all times, but this is actually required now because the sessions require that the agent initiates the connection to establish their endpoint.

**Tested**
- Ran the agent without the -n flag and verified that an agent sitting behind a NAT still works as usual.
- Verified the logs indicate the initial session request is made.
- Verified that the -p flag still works as expected.