### PR TITLE
Handle agent reconnection gracefully

### DIFF
--- a/src/monitor.sh
+++ b/src/monitor.sh
@@ -22,7 +22,7 @@ while true; do
 
   CurrentSessions=$(tail -1 $MessagesFile)
 
-  if [ "$CurrentSessions" != "$LastSessions" ]; then
+  if [ "$CurrentSessions" != "" ] && [ "$CurrentSessions" != "$LastSessions" ]; then
     # Update the proxy and wireguard configuration since the sessions have changed.
 
     if [ "$ProxyStarted" == "false" ]; then


### PR DESCRIPTION
The agent's websocket to Reflect might get disconnected at times. When this happens, the agent reconnects to the endpoint, but during that time, the messages.txt log that we tail gets reset. When this happens, the monitor script will see an empty string and interpret it as the list of active sessions.
When it tries to toggle the wireguard interface, it'll fail because the empty string appears to be a missing argument. This, in turn, causes the monitor to exit, and the agent will never reconfigure its wireguard interface again.

This commit updates the monitor logic to not try to interpret the latest message as the list of active sessions unless its non-empty.

**Tested**
- Repro'd the bug with a forced reconnection and verified the fix handles it