### PR TITLE
Add heartbeat to control connection

### DIFF
--- a/src/connect.sh
+++ b/src/connect.sh
@@ -13,22 +13,22 @@ OutputFile=$3
 
 EncodedPublicKey=$(echo $PublicKey | jq -R -r @uri)
 
-SessionsCommand="sessions"
+IntervalSeconds=55
+TotalIntervals=11
+RestartSeconds=0.3
 
 echo "agent: connecting"
 
 while true; do
 
-  # This initial command causes the server to immediately send the active session after connection.
-  # The stdin stream actually closes after echo completes, so no further commands can be sent.
-  # That's fine since the agent simply listens for messages after its initial command.
-  # The -n flag below is required to ensure that websocat stays open even after stdin EOF.
-  echo $SessionsCommand | \
-    websocat -n wss://agent.reflect.run/api/agents/${EncodedPublicKey} \
+  # Periodically echo the "sessions" command to improve the chances of the websocket staying alive.
+  # But still reset and reconnect every 10 minutes or so, or if the server drops the connection.
+  ./output.sh $IntervalSeconds $TotalIntervals | \
+    websocat wss://agent.reflect.run/api/agents/${EncodedPublicKey} \
     -H "X-API-KEY:${ReflectApiKey}" | \
     tee $OutputFile
 
   # If the server disconnects due to a deployment or failure, reconnect.
-  sleep 1
+  sleep $RestartSeconds
   echo "agent: reconnecting"
 done

--- a/src/output.sh
+++ b/src/output.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Echo the SessionsCommand every interval, for X intervals.
+# This is used in conjunction with the connect.sh script
+# to maintain a persistent connection to the Reflect API,
+# which is distinct from the individual browser (Wireguard) connections.
+
+if [ $# -lt 2 ]; then
+  echo "usage: $0 <interval-secs> <num-intervals>"
+  exit 1
+fi
+
+IntervalSeconds=$1
+TotalIntervals=$2
+CurrentInterval=0
+
+SessionsCommand="sessions"
+
+while (( ++CurrentInterval <= TotalIntervals )); do
+  echo $SessionsCommand
+
+  if [ "$CurrentInterval" != "$TotalIntervals" ]; then
+    sleep $IntervalSeconds
+  fi
+done


### PR DESCRIPTION
Fixes #17

This commit updates the control websocket connection to send a heartbeat command every minute or so in order to reduce the chances of a middlebox terminating the connection.

This should also slightly reduce the latency in learning of new sessions.

**Tested**
- Ran the agent locally and verified recordings and runs are working
- Reduced the interval count to confirm it resets automatically